### PR TITLE
Introduce --disable-telepresence flag to cellery test command Improve cell testing

### DIFF
--- a/components/cli/cmd/cellery/test.go
+++ b/components/cli/cmd/cellery/test.go
@@ -38,6 +38,7 @@ func newTestCommand(cli cli.Cli) *cobra.Command {
 	var debug bool
 	var verbose bool
 	var incell bool
+	var disableTelepresence bool
 	var startDependencies bool
 	var shareAllInstances bool
 	var assumeYes bool
@@ -90,23 +91,24 @@ func newTestCommand(cli cli.Cli) *cobra.Command {
 						return fmt.Errorf("path %s does not exist", filepath.Join(projLocation, constants.BallerinaToml))
 					}
 				}
+				if disableTelepresence {
+					return fmt.Errorf("Telepresence is required to run on debug mode")
+				}
 			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := image2.RunTest(cli, args[0], name, startDependencies, shareAllInstances, dependencyLinks, envVars,
-				assumeYes, debug, verbose, incell, projLocation); err != nil {
+				assumeYes, debug, verbose, disableTelepresence, incell, projLocation); err != nil {
 				util.ExitWithErrorMessage("Cellery test command failed", err)
 			}
 		},
 		Example: "  cellery test cellery-samples/hr:1.0.0 -n hr-inst\n" +
-			"  cellery test cellery-samples/hr:1.0.0 -n hr-inst -y\n" +
-			"  cellery test cellery-samples/hr:1.0.0 -n hr-inst --assume-yes\n" +
+			"  cellery test cellery-samples/hr:1.0.0 -n hr-inst \n" +
+			"  cellery test cellery-samples/hr:1.0.0 -n hr-inst \n" +
+			"  cellery test cellery-samples/hr:1.0.0 -n hr-inst --disable-telepresence\n" +
 			"  cellery test registry.foo.io/cellery-samples/hr:1.0.0 -n hr-inst -l employee:employee-inst" +
-			" -l stock:stock-inst \n" +
-			" -v\n" +
-			" --debug\n" +
-			" -p ~/cellery-samples/cells/employee-portal/hr_proj",
+			" -l stock:stock-inst -v --debug -p ~/cellery-samples/cells/employee-portal/hr_proj",
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name of the cell instance")
 	cmd.Flags().BoolVarP(&assumeYes, "assume-yes", "y", false,
@@ -119,8 +121,8 @@ func newTestCommand(cli cli.Cli) *cobra.Command {
 		"Link an instance with a dependency alias")
 	cmd.Flags().StringArrayVarP(&envVars, "env", "e", []string{},
 		"Set an environment variable for the cellery test method in the Cell file")
-
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Run on verbose mode")
+	cmd.Flags().BoolVar(&disableTelepresence, "disable-telepresence", false, "Disable Telepresence")
 	cmd.Flags().BoolVar(&debug, "debug", false, "Enable test debug mode")
 	cmd.Flags().StringVarP(&projLocation, "project-location", "p", "", "Ballerina Project location")
 	cmd.Flags().BoolVar(&incell, "incell", false, "Enable in-cell testing")

--- a/components/cli/cmd/cellery/test.go
+++ b/components/cli/cmd/cellery/test.go
@@ -92,7 +92,7 @@ func newTestCommand(cli cli.Cli) *cobra.Command {
 					}
 				}
 				if disableTelepresence {
-					return fmt.Errorf("Telepresence is required to run on debug mode")
+					return fmt.Errorf("Telepresence is required to debug tests")
 				}
 			}
 			return nil

--- a/components/cli/pkg/util/file_operations.go
+++ b/components/cli/pkg/util/file_operations.go
@@ -30,6 +30,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/constants"
@@ -206,6 +207,27 @@ func FindInDirectory(directory, suffix string) []string {
 		}
 	}
 	return fileList
+}
+
+func FindPatternInFile(searchString string, filePath string) (bool, error) {
+	// Read file content
+	content, err := ioutil.ReadFile(filePath)
+	contentStr := string(content)
+
+	// Remove comments
+	regex, err := regexp.Compile(`\s*(/{2,}|#+).*`)
+	if err != nil {
+		return false, err
+	}
+	contentStr = regex.ReplaceAllString(contentStr, "")
+
+	// Search for the given string
+	matchStr := regexp.MustCompile(`[\n;}]\s*` + searchString)
+	if err != nil {
+		return false, err
+	}
+
+	return matchStr.MatchString(contentStr), nil
 }
 
 func CreateDir(dirPath string) error {


### PR DESCRIPTION
## Purpose
> Introduces the --disable-telepresence flag to cellery test command. Resolves #766 
> Print a warning if @BeforeSuite or @AfterSuite functions are not defined in tests. Resolves #965
> Improve native functions for cell testing. Resolves #970