### PR TITLE
Revert "Add tracing-agent.yaml and Change mixer-adapter.yaml to telemetry-age…"

### DIFF
--- a/components/cli/pkg/runtime/gcp/observability.go
+++ b/components/cli/pkg/runtime/gcp/observability.go
@@ -66,7 +66,6 @@ func buildObservabilityYamlPaths() []string {
 		filepath.Join(base, "portal", "observability-portal.yaml"),
 		filepath.Join(base, "prometheus", "k8s-metrics-prometheus.yaml"),
 		filepath.Join(base, "grafana", "k8s-metrics-grafana.yaml"),
-		filepath.Join(base, "observability-agent", "telemetry-agent.yaml"),
-		filepath.Join(base, "observability-agent", "tracing-agent.yaml"),
+		filepath.Join(base, "mixer-adapter", "mixer-adapter.yaml"),
 	}
 }

--- a/components/cli/pkg/runtime/observability.go
+++ b/components/cli/pkg/runtime/observability.go
@@ -76,8 +76,7 @@ func buildObservabilityYamlPaths(artifactsPath string) []string {
 		filepath.Join(base, "portal", "observability-portal.yaml"),
 		filepath.Join(base, "prometheus", "k8s-metrics-prometheus.yaml"),
 		filepath.Join(base, "grafana", "k8s-metrics-grafana.yaml"),
-		filepath.Join(base, "observability-agent", "telemetry-agent.yaml"),
-		filepath.Join(base, "observability-agent", "tracing-agent.yaml"),
+		filepath.Join(base, "mixer-adapter", "mixer-adapter.yaml"),
 	}
 }
 


### PR DESCRIPTION
Reverts wso2/cellery#975
Reverting until change is applied to distribution and mesh observability repos.