### PR TITLE
Add tracing-agent.yaml and Change mixer-adapter.yaml to telemetry-agent.yaml

### DIFF
--- a/components/cli/pkg/runtime/gcp/observability.go
+++ b/components/cli/pkg/runtime/gcp/observability.go
@@ -66,6 +66,7 @@ func buildObservabilityYamlPaths() []string {
 		filepath.Join(base, "portal", "observability-portal.yaml"),
 		filepath.Join(base, "prometheus", "k8s-metrics-prometheus.yaml"),
 		filepath.Join(base, "grafana", "k8s-metrics-grafana.yaml"),
-		filepath.Join(base, "mixer-adapter", "mixer-adapter.yaml"),
+		filepath.Join(base, "observability-agent", "telemetry-agent.yaml"),
+		filepath.Join(base, "observability-agent", "tracing-agent.yaml"),
 	}
 }

--- a/components/cli/pkg/runtime/observability.go
+++ b/components/cli/pkg/runtime/observability.go
@@ -76,7 +76,8 @@ func buildObservabilityYamlPaths(artifactsPath string) []string {
 		filepath.Join(base, "portal", "observability-portal.yaml"),
 		filepath.Join(base, "prometheus", "k8s-metrics-prometheus.yaml"),
 		filepath.Join(base, "grafana", "k8s-metrics-grafana.yaml"),
-		filepath.Join(base, "mixer-adapter", "mixer-adapter.yaml"),
+		filepath.Join(base, "observability-agent", "telemetry-agent.yaml"),
+		filepath.Join(base, "observability-agent", "tracing-agent.yaml"),
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Apply tracing-agent.yaml when enabling observability. related to wso2/cellery-observability#94

## Approach
> Add tracing-agent.yaml path to both runtime and gcp.
